### PR TITLE
AF-3833 Add authors, homepage, and description fields; make public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 0.1.0
+
+- Initial release!

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,14 @@
 name: codemod
-private: true
 version: 0.1.0
+homepage: https://github.com/Workiva/dart_codemod
+
+description: >
+  Write and run automated code modifications on a codebase. Primarily geared
+  towards updating and refactoring Dart code, but can modify any files.
+
+authors:
+  - Workiva Client Platform Team <clientplatform@workiva.com>
+  - Evan Weible <evan.weible@workiva.com>
 
 environment:
   sdk: ">=2.1.0 <3.0.0"


### PR DESCRIPTION
## Description
Before we can publish an initial release, we need to make some changes to the `pubspec.yaml`:

- Add `homepage`
- Add `description`
- Add `authors`
- Remove `private: true`

Also added a `CHANGELOG.md`

## Code Review
@corwinsheahan-wf @sebastianmalysa-wf @robbecker-wf 