### PR TITLE
AF-3910 Additional tests; fix typing issue in AggregateSuggestor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
-# 0.1.0
+## 0.1.2
 
-- Initial release!
+- Fix a typing issue with the `AggregateSuggestor`'s constructor param.
+
+- Add tests for `AggregateSuggestor` and `AstVisitingSuggestorMixin`
+
+## 0.1.1
+
+- Update `pubspec.yaml` for initial OSS release.
+
+## 0.1.0
+
+- Initial tag.

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,9 @@ RUN chmod 700 /root/.ssh/
 RUN chmod 600 /root/.ssh/id_rsa
 
 RUN pub get
-RUN dartanalyzer .
 RUN pub run dart_dev format --check
+RUN dartanalyzer .
+RUN pub run dependency_validator -i dart_style,pedantic
 RUN pub run test
 
 ARG BUILD_ARTIFACTS_BUILD=/build/pubspec.lock

--- a/lib/src/suggestors.dart
+++ b/lib/src/suggestors.dart
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import 'package:analyzer/analyzer.dart';
+import 'package:meta/meta.dart';
 import 'package:source_span/source_span.dart';
 
 import 'patch.dart';
@@ -120,9 +121,12 @@ abstract class Suggestor {
 ///       ]),
 ///     );
 class AggregateSuggestor implements Suggestor {
-  final List<Suggestor> _suggestors;
+  final Iterable<Suggestor> _suggestors;
 
   AggregateSuggestor(Iterable<Suggestor> suggestors) : _suggestors = suggestors;
+
+  @visibleForTesting
+  Iterable<Suggestor> get aggregatedSuggestors => _suggestors.toList();
 
   @override
   Iterable<Patch> generatePatches(SourceFile sourceFile) sync* {
@@ -136,7 +140,7 @@ class AggregateSuggestor implements Suggestor {
   }
 
   @override
-  bool shouldSkip(String sourceFileContents) => false;
+  bool shouldSkip(_) => false;
 }
 
 /// Mixin that implements the [Suggestor] interface and makes it easier to write

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   args: ^1.5.1
   io: ^0.3.3
   logging: ^0.11.3+2
+  meta: ^1.1.7
   path: ^1.6.2
   source_span: ^1.4.1
   stack_trace: ^1.9.3

--- a/test/aggregate_suggestor_test.dart
+++ b/test/aggregate_suggestor_test.dart
@@ -1,0 +1,101 @@
+// Copyright 2019 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@TestOn('vm')
+import 'package:codemod/codemod.dart';
+import 'package:mockito/mockito.dart';
+import 'package:source_span/source_span.dart';
+import 'package:test/test.dart';
+
+class BaseSuggestor implements Suggestor {
+  @override
+  bool shouldSkip(_) => false;
+
+  @override
+  Iterable<Patch> generatePatches(_) sync* {}
+}
+
+class AlwaysSkips extends BaseSuggestor {
+  @override
+  bool shouldSkip(_) => true;
+
+  @override
+  Iterable<Patch> generatePatches(_) => [ShouldBeSkippedPatch()];
+}
+
+class FooSuggestor extends BaseSuggestor {
+  @override
+  Iterable<Patch> generatePatches(_) => [FooPatch()];
+}
+
+class BarSuggestor extends BaseSuggestor {
+  @override
+  Iterable<Patch> generatePatches(_) => [BarPatch()];
+}
+
+class MockPatch extends Mock implements Patch {}
+
+class FooPatch extends MockPatch {}
+
+class BarPatch extends MockPatch {}
+
+class ShouldBeSkippedPatch extends MockPatch {}
+
+void main() {
+  group('AggregateSuggestor', () {
+    test('accepts a list of Suggestors', () {
+      final foo = BaseSuggestor();
+      final bar = BaseSuggestor();
+      final aggregate = AggregateSuggestor([foo, bar]);
+      expect(aggregate.aggregatedSuggestors, [foo, bar]);
+    });
+
+    test('accepts an iterable of Suggestors', () {
+      final foo = BaseSuggestor();
+      final bar = BaseSuggestor();
+      final aggregate = AggregateSuggestor([foo, bar].map((s) => s));
+      expect(aggregate.aggregatedSuggestors, [foo, bar]);
+    });
+
+    test('shouldSkip() always returns false', () {
+      final aggregate = AggregateSuggestor([AlwaysSkips()]);
+      expect(aggregate.shouldSkip(''), isFalse);
+    });
+
+    group('generatePatches()', () {
+      test('skips suggestors that return true from shouldSkip()', () {
+        final aggregate = AggregateSuggestor([
+          AlwaysSkips(),
+          FooSuggestor(),
+        ]);
+        final sourceFile = SourceFile.fromString('test');
+        final patches = aggregate.generatePatches(sourceFile);
+        expect(patches, hasLength(1));
+        expect(patches.single, TypeMatcher<FooPatch>());
+      });
+
+      test('should yield patches from each suggestor', () {
+        final aggregate = AggregateSuggestor([
+          FooSuggestor(),
+          BarSuggestor(),
+        ]);
+        final sourceFile = SourceFile.fromString('test');
+        final patches = aggregate.generatePatches(sourceFile).toList();
+        expect(patches, hasLength(2));
+        expect(patches[0], TypeMatcher<FooPatch>());
+        expect(patches[1], TypeMatcher<BarPatch>());
+      });
+    });
+  });
+}

--- a/test/ast_visiting_suggestor_mixin_test.dart
+++ b/test/ast_visiting_suggestor_mixin_test.dart
@@ -1,0 +1,80 @@
+// Copyright 2019 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@TestOn('vm')
+import 'package:analyzer/analyzer.dart';
+import 'package:codemod/codemod.dart';
+import 'package:source_span/source_span.dart';
+import 'package:test/test.dart';
+
+class Simple extends SimpleAstVisitor with AstVisitingSuggestorMixin {
+  @override
+  visitCompilationUnit(_) {
+    yieldPatch(0, 1, 'foo');
+  }
+}
+
+void main() {
+  group('AstVisitingSuggestorMixin', () {
+    test('should make the sourceFile available', () {
+      final suggestor = Simple();
+      final sourceFile = SourceFile.fromString(' ');
+      suggestor.generatePatches(sourceFile).toList();
+      expect(suggestor.sourceFile, sourceFile);
+    });
+
+    test('shouldSkip() returns false by default', () {
+      final suggestor = Simple();
+      expect(suggestor.shouldSkip(''), isFalse);
+    });
+
+    group('generatePatches()', () {
+      test('should parse compilation unit, visit it, and yield patches', () {
+        final suggestor = Simple();
+        final sourceFile = SourceFile.fromString('library lib;');
+        final patches = suggestor.generatePatches(sourceFile);
+        expect(patches, hasLength(1));
+        expect(patches.single.startOffset, 0);
+        expect(patches.single.endOffset, 1);
+        expect(patches.single.updatedText, 'foo');
+      });
+
+      test('should be able to be run multiple times', () {
+        final suggestor = Simple();
+
+        final sourceFileA = SourceFile.fromString('library a;');
+        final patchesA = suggestor.generatePatches(sourceFileA);
+        expect(patchesA, hasLength(1));
+        expect(patchesA.single.startOffset, 0);
+        expect(patchesA.single.endOffset, 1);
+        expect(patchesA.single.updatedText, 'foo');
+        expect(suggestor.sourceFile, sourceFileA);
+
+        final sourceFileB = SourceFile.fromString('library b;');
+        final patchesB = suggestor.generatePatches(sourceFileB);
+        expect(patchesB, hasLength(1));
+        expect(patchesB.single.startOffset, 0);
+        expect(patchesB.single.endOffset, 1);
+        expect(patchesB.single.updatedText, 'foo');
+        expect(suggestor.sourceFile, sourceFileB);
+      });
+    });
+
+    test(
+        'yieldPatch() should throw StateError if called outside generatePatches()',
+        () {
+      expect(() => Simple().yieldPatch(0, 0, ''), throwsStateError);
+    });
+  });
+}


### PR DESCRIPTION
## Description
- Need tests for `AggregateSuggestor` and `AggregateSuggestor`
- `AggregateSuggestor` is typed such that it should accept an `Iterable`, but currently throws when accepting anything other than a list because of how the private field is typed

## Changes
- Add tests
- Fix typing issue in `AggregateSuggestor`

## Testing
- [ ] CI passes

## Code Review
@corwinsheahan-wf @sebastianmalysa-wf @georgelesica-wf @robbecker-wf @maxwellpeterson-wf 