### PR TITLE
AF-3962 Fix syntax error in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,10 +260,10 @@ provided by this library:
       final query = ...;
       exitCode = runInteractiveCodemod(
         query,
-        AggregateSuggestor(
+        AggregateSuggestor([
           SuggestorA(),
           SuggestorB(),
-        ),
+        ]),
       );
     }
     ```


### PR DESCRIPTION
The `AggregateSuggestor` usage example in the readme has a syntax error – the constructor takes a single iterable of suggestors, but the example is currently passing in multiple suggestors as individual args.

@corwinsheahan-wf @sebastianmalysa-wf @maxwellpeterson-wf 