### PR TITLE
CPLAT-4057 Provide API for consumers to augment help and error output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .dart_tool/
-.packages/
+.packages
 pubspec.lock

--- a/lib/src/run_interactive_codemod.dart
+++ b/lib/src/run_interactive_codemod.dart
@@ -144,7 +144,8 @@ int runInteractiveCodemodSequence(
     return overrideAnsiOutput<int>(
         stdout.supportsAnsiEscapes,
         () => _runInteractiveCodemod(query, suggestors, parsedArgs,
-            defaultYes: defaultYes, changesRequiredOutput: changesRequiredOutput));
+            defaultYes: defaultYes,
+            changesRequiredOutput: changesRequiredOutput));
   } catch (error, stackTrace) {
     stderr..writeln('Uncaught exception:')..writeln(error)..writeln(stackTrace);
     return ExitCode.software.code;

--- a/lib/src/run_interactive_codemod.dart
+++ b/lib/src/run_interactive_codemod.dart
@@ -78,12 +78,16 @@ int runInteractiveCodemod(
   Suggestor suggestor, {
   Iterable<String> args,
   bool defaultYes = false,
+  String additionalHelpOutput,
+  String changesRequiredOutput,
 }) =>
     runInteractiveCodemodSequence(
       query,
       [suggestor],
       args: args,
       defaultYes: defaultYes,
+      additionalHelpOutput: additionalHelpOutput,
+      changesRequiredOutput: changesRequiredOutput,
     );
 
 /// Exactly the same as [runInteractiveCodemod] except that it runs all of the
@@ -108,6 +112,8 @@ int runInteractiveCodemodSequence(
   Iterable<Suggestor> suggestors, {
   Iterable<String> args,
   bool defaultYes = false,
+  String additionalHelpOutput,
+  String changesRequiredOutput,
 }) {
   try {
     ArgResults parsedArgs;
@@ -122,14 +128,23 @@ int runInteractiveCodemodSequence(
     }
 
     if (parsedArgs['help'] == true) {
+      stderr.writeln('Global codemod options:');
+      stderr.writeln();
       stderr.writeln(codemodArgParser.usage);
+
+      additionalHelpOutput ??= '';
+      if (additionalHelpOutput.isNotEmpty) {
+        stderr.writeln();
+        stderr.writeln('Additional options for this codemod:');
+        stderr.writeln(additionalHelpOutput);
+      }
       return ExitCode.success.code;
     }
 
     return overrideAnsiOutput<int>(
         stdout.supportsAnsiEscapes,
         () => _runInteractiveCodemod(query, suggestors, parsedArgs,
-            defaultYes: defaultYes));
+            defaultYes: defaultYes, changesRequiredOutput: changesRequiredOutput));
   } catch (error, stackTrace) {
     stderr..writeln('Uncaught exception:')..writeln(error)..writeln(stackTrace);
     return ExitCode.software.code;
@@ -169,7 +184,7 @@ final codemodArgParser = ArgParser()
 
 int _runInteractiveCodemod(
     FileQuery query, Iterable<Suggestor> suggestors, ArgResults parsedArgs,
-    {bool defaultYes}) {
+    {bool defaultYes, String changesRequiredOutput}) {
   final failOnChanges = parsedArgs['fail-on-changes'] ?? false;
   final stderrAssumeTty = parsedArgs['stderr-assume-tty'] ?? false;
   final verbose = parsedArgs['verbose'] ?? false;
@@ -295,6 +310,12 @@ int _runInteractiveCodemod(
   if (failOnChanges) {
     if (numChanges > 0) {
       stderr.writeln('$numChanges change(s) needed.');
+
+      changesRequiredOutput ??= '';
+      if (changesRequiredOutput.isNotEmpty) {
+        stderr.writeln();
+        stderr.writeln(changesRequiredOutput);
+      }
       return 1;
     }
     stdout.writeln('No changes needed.');

--- a/test/functional/run_interactive_codemod_test.dart
+++ b/test/functional/run_interactive_codemod_test.dart
@@ -108,14 +108,15 @@ void expectProjectsMatch(String goldPath, String testPath) {
 
 void main() {
   group('runInteractiveCodemod', () {
-    testCodemod('--help outputs usage help text', _afterNoPatches, 
+    testCodemod('--help outputs usage help text', _afterNoPatches,
         args: ['--help'], body: (out, err) {
-      expect(err, contains('Global codemod options:\n\n' + codemodArgParser.usage));
+      expect(err,
+          contains('Global codemod options:\n\n' + codemodArgParser.usage));
     });
 
-    testCodemod('--help outputs additional help text if provided', _afterNoPatches, 
-        script: 'codemod_help_output.dart',
-        args: ['--help'], body: (out, err) {
+    testCodemod(
+        '--help outputs additional help text if provided', _afterNoPatches,
+        script: 'codemod_help_output.dart', args: ['--help'], body: (out, err) {
       expect(err, contains('additional help output'));
     });
 

--- a/test/functional/run_interactive_codemod_test.dart
+++ b/test/functional/run_interactive_codemod_test.dart
@@ -108,9 +108,15 @@ void expectProjectsMatch(String goldPath, String testPath) {
 
 void main() {
   group('runInteractiveCodemod', () {
-    testCodemod('--help outputs usage help text', _afterNoPatches,
+    testCodemod('--help outputs usage help text', _afterNoPatches, 
         args: ['--help'], body: (out, err) {
-      expect(err, contains(codemodArgParser.usage));
+      expect(err, contains('Global codemod options:\n\n' + codemodArgParser.usage));
+    });
+
+    testCodemod('--help outputs additional help text if provided', _afterNoPatches, 
+        script: 'codemod_help_output.dart',
+        args: ['--help'], body: (out, err) {
+      expect(err, contains('additional help output'));
     });
 
     testCodemod('skips all patches via prompts', _afterNoPatches,
@@ -163,6 +169,14 @@ void main() {
         expectedExitCode: 1,
         script: 'codemod.dart', body: (out, err) {
       expect(err, contains('6 change(s) needed.'));
+    });
+
+    testCodemod('--fail-on-changes adds extra text to output when provided',
+        _afterNoPatches,
+        args: ['--fail-on-changes'],
+        expectedExitCode: 1,
+        script: 'codemod_changes_required_output.dart', body: (out, err) {
+      expect(err, contains('6 change(s) needed.\n\nchanges required output'));
     });
   });
 }

--- a/test_fixtures/functional/before/codemod.dart
+++ b/test_fixtures/functional/before/codemod.dart
@@ -7,12 +7,14 @@ void main(List<String> args) {
   run(args);
 }
 
-void run(List<String> args, {bool defaultYes}) {
+void run(List<String> args, {bool defaultYes, String additionalHelpOutput, String changesRequiredOutput}) {
   exitCode = runInteractiveCodemod(
     FileQuery.dir(pathFilter: (path) => path.endsWith('.txt')),
     TestSuggestor(),
     args: args,
     defaultYes: defaultYes,
+    additionalHelpOutput: additionalHelpOutput,
+    changesRequiredOutput: changesRequiredOutput,
   );
 }
 

--- a/test_fixtures/functional/before/codemod_changes_required_output.dart
+++ b/test_fixtures/functional/before/codemod_changes_required_output.dart
@@ -1,0 +1,5 @@
+import 'codemod.dart';
+
+void main(List<String> args) {
+  run(args, changesRequiredOutput: 'changes required output');
+}

--- a/test_fixtures/functional/before/codemod_help_output.dart
+++ b/test_fixtures/functional/before/codemod_help_output.dart
@@ -1,0 +1,5 @@
+import 'codemod.dart';
+
+void main(List<String> args) {
+  run(args, additionalHelpOutput: 'additional help output');
+}


### PR DESCRIPTION
This PR provides API for consumers to augment:
1.) `--help` output (i.e. if consuming codemods have additional options),
2.) `--fail-on-changes` output (i.e. to instruct users to make required changes)

Addresses https://github.com/Workiva/dart_codemod/issues/17 and https://github.com/Workiva/dart_codemod/issues/18