### PR TITLE
Fix `pathLooksLikeCode` to exclude build folder

### DIFF
--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -159,8 +159,7 @@ bool pathLooksLikeCode(String filePath) =>
     !filePath.contains('/.') &&
     !filePath.contains('dev.dart') &&
     !(filePath.startsWith('.') && !filePath.startsWith('./')) &&
-    !filePath.contains('build/packages') &&
-    !filePath.contains('build/test');
+    !filePath.startsWith('build/');
 
 /// Prompts the user to select an action via stdin.
 ///

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -157,7 +157,10 @@ bool isDartFile(String filePath) => path.extension(filePath) == '.dart';
 ///     // False
 bool pathLooksLikeCode(String filePath) =>
     !filePath.contains('/.') &&
-    !(filePath.startsWith('.') && !filePath.startsWith('./'));
+    !filePath.contains('dev.dart') &&
+    !(filePath.startsWith('.') && !filePath.startsWith('./')) &&
+    !filePath.contains('build/packages') &&
+    !filePath.contains('build/test');
 
 /// Prompts the user to select an action via stdin.
 ///


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
Codemods run on the `build/` folder after the package is built. Not only do we not want to do this, it can cause `generatePatches()` to throw an exception here and the codemod will fail: https://github.com/Workiva/dart_codemod/blob/master/lib/src/suggestors.dart#L191 

## Changes
  <!-- What this PR changes to fix the problem. -->
Exclude paths starting with `build/` from the "looking like code" filter. 

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-client-plat Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] CI passes

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/dart_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/dart_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
