### PR TITLE
CPLAT-6476 Allow executors to include or exclude files when running codemods

### DIFF
--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -155,11 +155,21 @@ bool isDartFile(String filePath) => path.extension(filePath) == '.dart';
 ///     // False
 ///     pathLooksLikeCode('.dart_tool/pub/bin/sdk-version')
 ///     // False
-bool pathLooksLikeCode(String filePath) =>
-    !filePath.contains('/.') &&
-    !filePath.contains('dev.dart') &&
-    !(filePath.startsWith('.') && !filePath.startsWith('./')) &&
-    !filePath.startsWith('build/');
+///
+/// If [includePaths] is provided, all filePaths that start with a path passed in
+/// this list will return true.
+bool pathLooksLikeCode(String filePath,
+    {List<String> includePaths = const []}) {
+  for (var path in includePaths) {
+    if (filePath.startsWith(path)) return true;
+  }
+
+  // By default, dotfile directories and the root build directory are not included
+  // as candidates for a codemod.
+  return !filePath.contains('/.') &&
+      !(filePath.startsWith('.') && !filePath.startsWith('./')) &&
+      !filePath.startsWith('build/');
+}
 
 /// Prompts the user to select an action via stdin.
 ///

--- a/test/util_test.dart
+++ b/test/util_test.dart
@@ -189,6 +189,29 @@ line 5;''');
         expect(pathLooksLikeCode('project/.dart_tool/'), isFalse);
       });
 
+      test('returns false if root path segment is build', () {
+        expect(pathLooksLikeCode('build/'), isFalse);
+        expect(pathLooksLikeCode('build/test.dart'), isFalse);
+        expect(pathLooksLikeCode('build/packages/test.dart'), isFalse);
+      });
+
+      test('returns true if non-root path segment is build', () {
+        expect(pathLooksLikeCode('lib/src/build/'), isTrue);
+        expect(pathLooksLikeCode('tool/build/test.dart'), isTrue);
+      });
+
+      test(
+          'returns true if root path segment is build and includeFiles contains build',
+          () {
+        expect(pathLooksLikeCode('build/', includePaths: ['build']), isTrue);
+        expect(pathLooksLikeCode('build/test.dart', includePaths: ['build']),
+            isTrue);
+        expect(
+            pathLooksLikeCode('build/packages/test.dart',
+                includePaths: ['build/']),
+            isTrue);
+      });
+
       test('returns true if path starts with dot but only to reference cwd',
           () {
         expect(pathLooksLikeCode('./lib/foo.dart'), isTrue);


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
This PR adds the `--include` or `--exclude` flags to allow codemod executors to further customize what files the codemod they're running does or does not modify.

Use case 1: The `pathLooksLikeCode` check always excludes the `build` folder, but someone running a codemod has something other than built assets in a root level `build` folder and wants to run the codemod on those files. 
Use case 2: The codemod `FileQuery` includes every Dart file (common pattern) but there are some (like dev.dart or generated files) that the executor knows they don't want to modify.
Use case 3: The codemod `FileQuery` includes a subset of Dart files, but there are some additional ones that the executor wants to add.

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-client-plat Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/dart_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/dart_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
