### PR TITLE
Add ability to use a resolved AST for complex codemods that require static types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [0.3.0](https://github.com/Workiva/dart_codemod/compare/0.2.0...0.3.0)
+
+- **Breaking Change:** `runInteractiveCodemod` is now async, and returns `Future<int>` instead of `int`
+
+- Adds a `ResolvedSuggestor` interface for Suggestors that require static analysis context 
+
+- Adds `ResolvedAstVisitingSuggestorMixin` which should be used for codemods that require static analysis
+
+- Add example of such a codemod: see [example/codemod_analysis_required.dart](https://github.com/Workiva/dart_codemod/tree/master/example/codemod_analysis_required.dart)
+
 ## [0.2.0](https://github.com/Workiva/dart_codemod/compare/0.1.5...0.2.0)
 
 - **Breaking Change:** remove the `FileQuery` class. The

--- a/example/codemod_analysis_required.dart
+++ b/example/codemod_analysis_required.dart
@@ -1,0 +1,40 @@
+import 'dart:io';
+
+import 'package:codemod/codemod.dart';
+import 'package:glob/glob.dart';
+// ignore: deprecated_member_use
+import 'package:analyzer/analyzer.dart';
+
+/// Removes all modulus operations on the int type and refactors them to use
+/// [int.isEven] and [int.isOdd].
+class IsEvenOrOddSuggestor extends GeneralizingAstVisitor
+    with ResolvedAstVisitingSuggestorMixin {
+  @override
+  void visitBinaryExpression(BinaryExpression node) {
+    if (node.leftOperand is BinaryExpression &&
+        node.rightOperand is IntegerLiteral) {
+      final left = node.leftOperand as BinaryExpression;
+      final right = node.rightOperand as IntegerLiteral;
+      if (left.operator.stringValue == '%' &&
+          node.operator.stringValue == '==') {
+        if (left.leftOperand.staticType.isDartCoreInt) {
+          if (right.value == 0) {
+            yieldPatch(left.leftOperand.end, node.end, '.isEven');
+          }
+          if (right.value == 1) {
+            yieldPatch(left.leftOperand.end, node.end, '.isOdd');
+          }
+        }
+      }
+    }
+    return super.visitBinaryExpression(node);
+  }
+}
+
+void main(List<String> args) async {
+  exitCode = await runInteractiveCodemod(
+    filePathsFromGlob(Glob('codemod_analysis_required_fixtures/**.dart')),
+    IsEvenOrOddSuggestor(),
+    args: args,
+  );
+}

--- a/example/codemod_analysis_required_fixtures/is_even.dart
+++ b/example/codemod_analysis_required_fixtures/is_even.dart
@@ -1,0 +1,8 @@
+// Change to isEven
+var foo = (250 + 2) % 2 == 0;
+
+// Change to isOdd
+var bar = (250 + 2) % 2 == 1;
+
+// No changes, not int modulus
+var baz = 25.0 % 2 == 0;

--- a/example/deprecated_remover.dart
+++ b/example/deprecated_remover.dart
@@ -41,8 +41,8 @@ class DeprecatedRemover extends GeneralizingAstVisitor<void>
   }
 }
 
-void main(List<String> args) {
-  exitCode = runInteractiveCodemod(
+void main(List<String> args) async {
+  exitCode = await runInteractiveCodemod(
     filePathsFromGlob(Glob('deprecated_remover_fixtures/**.dart')),
     DeprecatedRemover(),
     args: args,

--- a/example/license_header_inserter.dart
+++ b/example/license_header_inserter.dart
@@ -55,8 +55,8 @@ class LicenseHeaderInserter implements Suggestor {
   }
 }
 
-void main(List<String> args) {
-  exitCode = runInteractiveCodemod(
+void main(List<String> args) async {
+  exitCode = await runInteractiveCodemod(
     filePathsFromGlob(Glob('license_header_fixtures/**.dart')),
     LicenseHeaderInserter(),
     args: args,

--- a/example/regex_substituter.dart
+++ b/example/regex_substituter.dart
@@ -53,8 +53,8 @@ class RegexSubstituter implements Suggestor {
   }
 }
 
-void main(List<String> args) {
-  exitCode = runInteractiveCodemod(
+void main(List<String> args) async {
+  exitCode = await runInteractiveCodemod(
     ['regex_substituter_fixtures/pubspec.yaml'],
     RegexSubstituter(),
     args: args,

--- a/lib/codemod.dart
+++ b/lib/codemod.dart
@@ -23,5 +23,10 @@ export 'src/patch.dart' show Patch;
 export 'src/run_interactive_codemod.dart'
     show runInteractiveCodemod, runInteractiveCodemodSequence;
 export 'src/suggestors.dart'
-    show AggregateSuggestor, AstVisitingSuggestorMixin, Suggestor;
+    show
+        AggregateSuggestor,
+        AstVisitingSuggestorMixin,
+        Suggestor,
+        ResolvedSuggestor,
+        ResolvedAstVisitingSuggestorMixin;
 export 'src/util.dart' show applyPatches;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: codemod
-version: 0.2.0
+version: 0.3.0
 homepage: https://github.com/Workiva/dart_codemod
 
 description: >

--- a/test_fixtures/functional/before/codemod.dart
+++ b/test_fixtures/functional/before/codemod.dart
@@ -3,15 +3,15 @@ import 'dart:io';
 import 'package:codemod/codemod.dart';
 import 'package:source_span/source_span.dart';
 
-void main(List<String> args) {
-  run(args);
+void main(List<String> args) async {
+  await run(args);
 }
 
-void run(List<String> args,
+Future<void> run(List<String> args,
     {bool defaultYes,
     String additionalHelpOutput,
-    String changesRequiredOutput}) {
-  exitCode = runInteractiveCodemod(
+    String changesRequiredOutput}) async {
+  exitCode = await runInteractiveCodemod(
     ['file1.txt', 'file2.txt', 'skip.txt'],
     TestSuggestor(),
     args: args,

--- a/test_fixtures/functional/before/codemod_no_patches.dart
+++ b/test_fixtures/functional/before/codemod_no_patches.dart
@@ -3,8 +3,8 @@ import 'dart:io';
 import 'package:codemod/codemod.dart';
 import 'package:glob/glob.dart';
 
-void main(List<String> args) {
-  exitCode = runInteractiveCodemod(
+void main(List<String> args) async {
+  exitCode = await runInteractiveCodemod(
       filePathsFromGlob(Glob('**')), NoopSuggestor(),
       args: args);
 }

--- a/test_fixtures/functional/before/codemod_overlapping_patches.dart
+++ b/test_fixtures/functional/before/codemod_overlapping_patches.dart
@@ -3,8 +3,8 @@ import 'dart:io';
 import 'package:codemod/codemod.dart';
 import 'package:source_span/source_span.dart';
 
-void main(List<String> args) {
-  exitCode = runInteractiveCodemod(
+void main(List<String> args) async {
+  exitCode = await runInteractiveCodemod(
       ['file1.txt', 'file2.txt', 'skip.txt'], OverlappingPatchSuggestor(),
       args: args);
 }

--- a/test_fixtures/functional/before/pubspec.yaml
+++ b/test_fixtures/functional/before/pubspec.yaml
@@ -1,7 +1,8 @@
 name: codemod_test_fixture
 version: 0.0.0
 private: true
-
+environment:
+    sdk: '>=2.10.0 <3.0.0'
 dev_dependencies:
   codemod:
     path: ../../../


### PR DESCRIPTION
## Motivation
I'm working on a codemod package for `package:riverpod`, and with some of the upcoming breaking changes I need to not only know the AST structure, but also the static types for some things. I tried a few things, but realized I would be reimplementing the resolving logic from `package:analyzer` if I tried to resolve things manually, in addition to the fact that resolving the AST requires understanding of multiple files.

Sorry for not seeing the contributing process earlier. But I think this should be pretty easy to review and clean. I've done some manual testing with the example. Let me know if this requires additional testing, and I can try to add it though it will be more complex than other tests.

## Changes
As listed in the updated changelog:
- **Breaking Change:** `runInteractiveCodemod` is now async, and returns `Future<int>` instead of `int`

- Adds a `ResolvedSuggestor` interface for Suggestors that require static analysis context 

- Adds `ResolvedAstVisitingSuggestorMixin` which should be used for codemods that require static analysis

- Add example of such a codemod: see example/codemod_analysis_required.dart

#### Release Notes
 ^ The above should be good I think.

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

@Workiva/app-frameworks

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [x] Manual testing was performed if needed
    - [x] Steps from PR author: 
        Run the new example `cd example && dart run codemod_analysis_required.dart`
    - [x] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/dart_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/dart_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
