### PR TITLE
CPLAT-14472: Include file path in parse errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.0.1](https://github.com/Workiva/dart_codemod/compare/1.0.0...1.0.1)
+
+- Include file path in error message when parsing a Dart file fails.
+
 ## [1.0.0](https://github.com/Workiva/dart_codemod/compare/0.3.0...1.0.0)
 
 - Null-safety release.


### PR DESCRIPTION
# [CPLAT-14472](https://jira.atl.workiva.net/browse/CPLAT-14472)
![Issue Status](http://bender.workiva.org:9000/Bender/status/CPLAT-14472)

## Motivation
Errors thrown by parseString don't include the filename, and result in the codemod halting without indicating which file it failed on.

Example
```
pub global run add_comment:add_comment
[INFO] Setting up analysis contexts...
[INFO] done
searching...
[SEVERE] Suggestor.generatePatches() threw unexpectedly.
Invalid argument(s): Content produced diagnostics when parsed:
  EXPECTED_TOKEN: Expected to find ';'. - 37:18
  ...
```

## Changes
Include file path in parse error messages

Before:
```
Invalid argument(s): Content produced diagnostics when parsed:
```
After:
```
Invalid argument(s): File "tools/analyzer_plugin/playground/web/invalid_invocations.dart" produced diagnostics when parsed
```
 
#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->
Include file path in parse error messages.

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-client-plat Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/dart_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/dart_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
