### PR TITLE
Widen Dependency Ranges Blocking Dart 2.13

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  analyzer: ^1.5.0
+  analyzer: ">=0.39.0 <0.42.0"
   args: ^2.0.0
   glob: ^2.0.1
   io: ^1.0.0
@@ -19,13 +19,13 @@ dependencies:
   quiver: ^3.0.0
   source_span: ^1.8.1
   stack_trace: ^1.10.0
-  test: ^1.16.8
+  test: ^1.15.7
   test_descriptor: ^2.0.0
 
 dev_dependencies:
   build_runner: ^2.0.1
   dart_style: ^2.0.0
   dependency_validator: ^3.0.0
-  meta: ^1.3.0
+  meta: ^1.2.2
   mockito: ^5.0.3
   pedantic: ^1.11.0


### PR DESCRIPTION
## Motivation
In order for projects to be compatible with Dart 2.13, there are dependencies that need to have their ranges widened. 
For a list of dependencies expected to be changed, see the dependencies section of the Dart 2.12+ [wiki page](https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832).

Another necessary change is the removal of `build_vm_compilers`. If this is the case, additional clean up may need to be done, such as removing the associated config from `build.yaml` or updating how tests are run. A member of Client Platform will be following up with PRs that have CI failures to resolve any issues or perform necessary clean up.

For any questions or concerns, don't hesitate to reach us in the #support-client-plat Slack channel!

## Changes
- Update specific dependencies to be compatible with Dart 2.13.
- Remove `build_vm_compilers` if it was present

## QA
- CI passes

[_Created by Sourcegraph batch change `Workiva/dart_213_dependency_range_widen`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/dart_213_dependency_range_widen)