### PR TITLE
Raise the Dart SDK minimum to at least 2.11.0

### DIFF
--- a/example/regex_substituter_fixtures/pubspec.yaml
+++ b/example/regex_substituter_fixtures/pubspec.yaml
@@ -4,3 +4,5 @@ version: 0.0.0
 
 dependencies:
   codemod: ^0.1.0
+environment:
+  sdk: '>=2.11.0 <3.0.0'

--- a/lib/src/run_interactive_codemod.dart
+++ b/lib/src/run_interactive_codemod.dart
@@ -145,7 +145,10 @@ Future<int> runInteractiveCodemodSequence(
             defaultYes: defaultYes,
             changesRequiredOutput: changesRequiredOutput));
   } catch (error, stackTrace) {
-    stderr..writeln('Uncaught exception:')..writeln(error)..writeln(stackTrace);
+    stderr
+      ..writeln('Uncaught exception:')
+      ..writeln(error)
+      ..writeln(stackTrace);
     return ExitCode.software.code;
   }
 }


### PR DESCRIPTION
## Overview
This updates the minimum Dart version that can be used to at least 2.11.0. Why 2.11.0 and not 2.13.4? Because setting it to 2.12.0 or higher opts the project into null safety (https://dart.dev/null-safety) which our code has not been migrated to yet. 
## What about null safety?
Once a project has been migrated to null safety it is ok to update the  minimum to 2.12.0 or even 2.13.4 since everyone at Workiva should be  using 2.13.4 now.
## Review / Testing / QA / Merge
If CI passes please review and merge. Most Dart CI has already been updated to run under 2.13.4 already so updating the minimum here doesn't change any code, or CI circumstances.
If CI fails, it's likely because an image in the Dockerfile or skynet.yaml is still running an older version of Dart. It should be updated to one with Dart 2.13. A list of existing 2.13 images lives here  https://wiki.atl.workiva.net/display/CP/Dart+2.13+Upgrade Feel free to fix CI and get this PR merged. However if you don't get to it, be aware that Client Platform will be going through the batch to help fix  any failures.
Please reach out to #support-client-plat with any questions.

[_Created by Sourcegraph batch change `Workiva/up_dart_sdk_minimum_to_2.11`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/up_dart_sdk_minimum_to_2.11)