### PR TITLE
Update analyzer dependency to 3.0.0

### DIFF
--- a/lib/src/ast_visiting_suggestor.dart
+++ b/lib/src/ast_visiting_suggestor.dart
@@ -63,13 +63,13 @@ mixin AstVisitingSuggestor<R> on AstVisitor<R> {
 
     CompilationUnit unit;
     if (shouldResolveAst(context)) {
-      var result = await context.getResolvedUnit();
-      if (result == null || result.unit == null) {
+      final result = await context.getResolvedUnit();
+      if (result == null) {
         _log.warning(
             'Could not get resolved unit for "${context.relativePath}"');
         return;
       }
-      unit = result.unit!;
+      unit = result.unit;
     } else {
       unit = context.getUnresolvedUnit();
     }

--- a/lib/src/file_context.dart
+++ b/lib/src/file_context.dart
@@ -47,7 +47,7 @@ class FileContext {
     final result = await _analysisContextCollection
         .contextFor(path)
         .currentSession
-        .getResolvedLibrary2(path);
+        .getResolvedLibrary(path);
     return result is ResolvedLibraryResult ? result : null;
   }
 
@@ -60,7 +60,7 @@ class FileContext {
     final result = await _analysisContextCollection
         .contextFor(path)
         .currentSession
-        .getResolvedUnit2(path);
+        .getResolvedUnit(path);
     return result is ResolvedUnitResult ? result : null;
   }
 

--- a/lib/src/run_interactive_codemod.dart
+++ b/lib/src/run_interactive_codemod.dart
@@ -24,7 +24,6 @@ import 'package:path/path.dart' as p;
 
 import 'logging.dart';
 import 'patch.dart';
-import 'suggestor.dart';
 import 'util.dart';
 
 /// Interactively runs a "codemod" by using `stdout` to display a diff for each

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -15,7 +15,6 @@
 import 'dart:math' as math;
 import 'dart:io';
 
-import 'package:codemod/codemod.dart';
 import 'package:io/ansi.dart';
 import 'package:source_span/source_span.dart';
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  analyzer: ^1.5.0
+  analyzer: ^3.0.0
   args: ^2.0.0
   glob: ^2.0.1
   io: ^1.0.0


### PR DESCRIPTION
## Motivation
Dart 2.15 introduced some new Dart syntax like constructor tear-offs. See this article for further information: https://medium.com/dartlang/dart-2-15-7e7a598e508a

The old version of the `analyzer` package the `codemod` package was using can't handle these new syntax constructs. This means you can't use the `codemod` package if your project uses new syntax constructs introduced by Dart 2.15.


  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->

## Changes
  <!-- What this PR changes to fix the problem. -->
Therefore I updated the `analyzer` dependency to use version 3.0.0 which enables users to use the `codemod` on projects which use Dart syntax constructs introduced by Dart 2.15.

I also fixed some small lints.

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->
Update `analyzer` dependency to version 3.0.0

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-client-plat Slack channel.

  -->

Please review: @Workiva/app-frameworks @evanweible-wf  <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [x] Manual testing was performed if needed
    - [x] Steps from PR author: 
       I tested the `codemod` package on a Flutter project using Dart 2.15 syntax constructs and it worked fine.

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/dart_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/dart_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
