### PR TITLE
Replace deprecated commands with new dart commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [1.0.4](https://github.com/Workiva/dart_codemod/compare/1.0.3...1.0.4)
+
+- Switch to replacements for deprecated Dart CLIs
+
+## [1.0.3](https://github.com/Workiva/dart_codemod/compare/1.0.2...1.0.3)
+
+- Fix wildcard in GitHub CI
+
+## [1.0.2](https://github.com/Workiva/dart_codemod/compare/1.0.1...1.0.2)
+
+- Raise Dart SDK minimum to 2.11.0
+
 ## [1.0.1](https://github.com/Workiva/dart_codemod/compare/1.0.0...1.0.1)
 
 - Include file path in error message when parsing a Dart file fails.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM google/dart:2 as build
 WORKDIR /build/
 ADD pubspec.yaml /build/
-RUN pub get
+RUN dart pub get
 FROM scratch

--- a/test/functional/run_interactive_codemod_test.dart
+++ b/test/functional/run_interactive_codemod_test.dart
@@ -58,8 +58,8 @@ Future<Null> testCodemod(
         .replaceAll('path: ../../../', 'path: ${p.current}'));
 
     final pubGetResult = await Process.run(
-      'pub',
-      ['get'],
+      'dart',
+      ['pub', 'get'],
       workingDirectory: projectDir.io.path,
     );
     if (pubGetResult.exitCode != 0) {


### PR DESCRIPTION
This Sourcegraph batch replaces deprecated commands from the Dart SDK with the new ones.
All new CLI commands now live under the main `dart` executable. See this issue for the details
https://github.com/dart-lang/sdk/issues/46100

This PR might need to be checked or tweaked for possible errors in the arguments to 
`dart analyze` and `dart format` since they take slightly different arguments than the original.
In most cases for analyze all the arguments can be removed and it can just be `dart analyze`.

Some of the argument changes were difficult to match and replace in an automated way. Since
there are only a few places that might break, it'll be easier to let the batch create the PR
and then manually adjust them.

### Argument changes for dartfmt -> dart format
`-w` should be removed automatically since overwriting files is now the default. But, if you spot one, remove it.
`--dry-run` is not a supported argument now. Replace with `--set-exit-if-changed -o none`

repos that look like they will need updates for dart format
- abide
- abide_archived
- bender.dart
- unscripted (unused repo)

### Argument changes for dartanalyzer -> dart analyze
`--no-hints` and `--no-lints` are removed

repos that look like they will need updates for dart analyze
- user_analytics


### QA steps:

- CI passing is a great start since these commands are usually called in the dockerfile, shell scripts, or skynet
- Check the changeset and if there are scripts that are only run locally and not in CI, try running them locally to verify they work
- If the PR has changes to `dart analyze` or `dart format` check the arguments
- Lastly, look for replacements that matched in the wrong place and should be undone or fixed

[_Created by Sourcegraph batch change `Workiva/dart_commands`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/dart_commands)