### PR TITLE
FEA-661: Update to analyer v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.0.10](https://github.com/Workiva/dart_codemod/compare/1.0.9...1.0.10)
+
+- Update analyzer dependency to v2
+
 ## [1.0.4](https://github.com/Workiva/dart_codemod/compare/1.0.3...1.0.4)
 
 - Switch to replacements for deprecated Dart CLIs

--- a/lib/src/ast_visiting_suggestor.dart
+++ b/lib/src/ast_visiting_suggestor.dart
@@ -64,12 +64,12 @@ mixin AstVisitingSuggestor<R> on AstVisitor<R> {
     CompilationUnit unit;
     if (shouldResolveAst(context)) {
       var result = await context.getResolvedUnit();
-      if (result == null || result.unit == null) {
+      if (result == null) {
         _log.warning(
             'Could not get resolved unit for "${context.relativePath}"');
         return;
       }
-      unit = result.unit!;
+      unit = result.unit;
     } else {
       unit = context.getUnresolvedUnit();
     }

--- a/lib/src/file_context.dart
+++ b/lib/src/file_context.dart
@@ -47,7 +47,7 @@ class FileContext {
     final result = await _analysisContextCollection
         .contextFor(path)
         .currentSession
-        .getResolvedLibrary2(path);
+        .getResolvedLibrary(path);
     return result is ResolvedLibraryResult ? result : null;
   }
 
@@ -60,7 +60,7 @@ class FileContext {
     final result = await _analysisContextCollection
         .contextFor(path)
         .currentSession
-        .getResolvedUnit2(path);
+        .getResolvedUnit(path);
     return result is ResolvedUnitResult ? result : null;
   }
 

--- a/lib/src/run_interactive_codemod.dart
+++ b/lib/src/run_interactive_codemod.dart
@@ -24,7 +24,6 @@ import 'package:path/path.dart' as p;
 
 import 'logging.dart';
 import 'patch.dart';
-import 'suggestor.dart';
 import 'util.dart';
 
 /// Interactively runs a "codemod" by using `stdout` to display a diff for each

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -15,7 +15,6 @@
 import 'dart:math' as math;
 import 'dart:io';
 
-import 'package:codemod/codemod.dart';
 import 'package:io/ansi.dart';
 import 'package:source_span/source_span.dart';
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  analyzer: ^1.5.0
+  analyzer: ^2.0.0
   args: ^2.0.0
   glob: ^2.0.1
   io: ^1.0.0


### PR DESCRIPTION
## Motivation
Update to analyzer v2 so that consumers can use this package with that dependency.

## Changes
- Update analyzer dependency to `^2.0.0`
- Address usages of analyzer APIs (some things were deprecated, some things were made non-nullable which makes certain null checks and conditional paths unnecessary)
