### PR TITLE
Analyzer v3, v4, and v5

### DIFF
--- a/.github/workflows/dart_ci.yaml
+++ b/.github/workflows/dart_ci.yaml
@@ -31,3 +31,25 @@ jobs:
         run: dart analyze
       - name: Run tests
         run: dart test
+
+  validate_analyzer:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sdk: [ stable ]
+        analyzer:
+          - ^2.0.0
+          - ^3.0.0
+          - ^4.0.0
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: ${{ matrix.sdk }}
+      - name: Update analyzer constraint to ${{ matrix.analyzer }}
+        run: dart pub remove analyzer && dart pub add analyzer:${{ matrix.analyzer }} && git diff pubspec.yaml
+      - name: Analyze project source
+        run: dart analyze
+      - name: Run tests
+        run: dart test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.0.11](https://github.com/Workiva/dart_codemod/compare/1.0.10...1.0.11)
+
+- Widen analyzer dependency range to include v3, v4, and v5.
+
 ## [1.0.10](https://github.com/Workiva/dart_codemod/compare/1.0.9...1.0.10)
 
 - Update analyzer dependency to v2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  analyzer: ^2.0.0
+  analyzer: '>=2.0.0 <6.0.0'
   args: ^2.0.0
   glob: ^2.0.1
   io: ^1.0.0


### PR DESCRIPTION
## Motivation
There are 3 newer major versions of the `analyzer` package, we should either widen our range or update our dependency based on compatibility. As it turns out, this package is unaffected by breaking changes made in analyzer v3, v4, and v5. In other words, it is already compatible with the next 3 major version in addition to v2.

## Changes
- Widen `analyzer` range to include v2 through v5.
- Update CI to run analysis and tests with all 4 major versions of `analyzer` that are included in this range.
