### PR TITLE
Pin mockito 5

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,7 +27,7 @@ dev_dependencies:
   dart_style: ^2.0.0
   dependency_validator: ^3.0.0
   meta: ^1.6.0
-  mockito: ^5.0.3
+  mockito: '>=5.0.0 <5.3.0' # pin to workaround https://github.com/dart-lang/mockito/issues/552
   pedantic: ^1.11.0
 dependency_validator:
   ignore:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,3 +29,6 @@ dev_dependencies:
   meta: ^1.6.0
   mockito: ^5.0.3
   pedantic: ^1.11.0
+dependency_validator:
+  ignore:
+    - mockito


### PR DESCRIPTION
Summary
---
Frontend Frameworks is updating dependencies! More details at
https://wiki.atl.workiva.net/display/CP/Dependency+Upgrades

We've discovered that mockito 5.3.0 is not compatible with analyzer 2x.
So as we work to get repos upgraded to analyzer 2, mockito will start to fail
to compile. We can avoid this by setting an upper bound to avoid the known bad version.
mockito 5.3.1 and higher are ok, but require analyzer 4+

This batch will change the mockito dependency from ^5.0.0 to `'>=5.0.0 <5.3.0'`
and may add a dependency_validator ignore for the pinned version of mockito
if neccessary.

A passing CI is sufficient QA (means mockito compiles and tests run).

For more info, reach out to Rob Becker in `#support-frontend-dx`

[_Created by Sourcegraph batch change `Workiva/pin_mockito_5`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/pin_mockito_5)