### PR TITLE
Rollout Analyzer 5

### DIFF
--- a/.github/workflows/dart_ci.yaml
+++ b/.github/workflows/dart_ci.yaml
@@ -39,11 +39,11 @@ jobs:
       matrix:
         sdk: [ stable ]
         analyzer:
-          - ^2.0.0
-          - ^3.0.0
-          - ^4.0.0
+          - ^5.0.0
+          # Uncomment once we're on Dart 2.19+
+          # - ^6.0.0
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dart-lang/setup-dart@v1
         with:
           sdk: ${{ matrix.sdk }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM google/dart:2 as build
+FROM dart:2.18 as build
 WORKDIR /build/
 ADD pubspec.yaml /build/
 RUN dart pub get

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   quiver: ^3.0.0
   source_span: ^1.8.1
   stack_trace: ^1.10.0
-  test: ^1.16.8
+  test: ^1.21.1
   test_descriptor: ^2.0.0
 
 dev_dependencies:
@@ -27,7 +27,7 @@ dev_dependencies:
   dart_style: ^2.0.0
   dependency_validator: ^3.0.0
   meta: ^1.6.0
-  mockito: '>=5.0.0 <5.3.0' # pin to workaround https://github.com/dart-lang/mockito/issues/552
+  mockito: ^5.3.2
   pedantic: ^1.11.0
 dependency_validator:
   ignore:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  analyzer: '>=2.0.0 <6.0.0'
+  analyzer: ^5.0.0
   args: ^2.0.0
   glob: ^2.0.1
   io: ^1.0.0
@@ -29,6 +29,3 @@ dev_dependencies:
   meta: ^1.6.0
   mockito: ^5.3.2
   pedantic: ^1.11.0
-dependency_validator:
-  ignore:
-    - mockito


### PR DESCRIPTION
# Rollout Analyzer 5

This batch will raise the minimum of workiva_dependency_constrainer
to one that requires analyzer 5, thus ensuring that a repo resolves
to analyzer 5. It also raises the minimums of other packages that
are needed, like built_value.

## Things that may need fixing manually

1. Probably the most common thing is that built_value generated code
will need to be regenerated. There should be no breaking changes in
this new generated code. Some repos have a make target called `gen`,
`gen-built` or similar, or just run a full `dart run build_runner build`

2. The temporary fix for Dart coverage needs to be removed. The fix
is to simply remove lines like these below from Github Actions. This PR
will have raised the minimum of the test package to 1.21.1 which is
the first version needed that removes the need to backpatched test
versions.
```
  - uses: Workiva/gha-dart/temp-coverage-setup@v0.2.28
    with:
      test-package-version: 1.20.1
```

3. As part of moving to analyzer 5, the sort_pub_dependencies lint 
seems to act as a warning now, causing analyze to fail CI.
To fix: either sort the dependencies in alphabetical order or
alter the analysis_options.yaml to lower the severity to a hint



For more info, reach out to `#support-frontend-dx` on Slack.

[_Created by Sourcegraph batch change `Workiva/analyzer_5`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/analyzer_5)