### PR TITLE
FEDX-522 Add APIs to help test suggestors with resolved AST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.2.0](https://github.com/Workiva/dart_codemod/compare/1.1.0...1.2.0)
+
+- Add `PackageContextForTest` to `package:codemod/test.dart` to help test
+suggestors that require a fully resolved AST from the analyzer (for example:
+suggestors using the `AstVisitingSuggestor` mixin with `shouldResolveAst`
+enabled).
+
 ## [1.1.0](https://github.com/Workiva/dart_codemod/compare/1.0.11...1.1.0)
 
 - Compatibility with Dart 3 and analyzer 6.

--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ import 'package:test/test.dart';
 void main() {
   group('AlwaysThrowsFixer', () {
     test('returns Never instead', () async {
-      final pkg = await PackageContextForTest.fromPubspec('pkg', '''
+      final pkg = await PackageContextForTest.fromPubspec('''
 name: pkg
 publish_to: none
 environment:
@@ -380,7 +380,7 @@ environment:
 dependencies:
   meta: ^1.0.0
 ''');
-      final context = await pkg.addFile('test.dart', '''
+      final context = await pkg.addFile('''
 import 'package:meta/meta.dart';
 @alwaysThrows toss() { throw 'Thrown'; }
 ''');

--- a/README.md
+++ b/README.md
@@ -349,6 +349,52 @@ var foo = 'foo';
 }
 ```
 
+### Testing Suggestors with Resolved AST
+
+The `fileContextForTest()` helper shown above makes it easy to test suggestors
+that operate on the _unresolved_ AST, but some suggestors require the _resolved_
+AST. For example, a suggestor may need to rename a specific symbol from a specific
+package, and so it would need to check the resolved element of a node. This is
+only possible if the analysis context is aware of all the relevant files and
+package dependencies.
+
+To help with this scenario, the `package:codemod/test.dart` library also exports
+a `PackageContextForTest` helper class. This class handles creating a temporary
+package directory, installing dependencies, and setting up an analysis context
+that has access to the whole package and its dependencies. You can then add
+source file(s) and use the wrapping `FileContext`s to test suggestors.
+
+```dart
+import 'package:codemod/codemod.dart';
+import 'package:source_span/source_span.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('AlwaysThrowsFixer', () {
+    test('returns Never instead', () async {
+      final pkg = await PackageContextForTest.fromPubspec('pkg', '''
+name: pkg
+publish_to: none
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+dependencies:
+  meta: ^1.0.0
+''');
+      final context = await pkg.addFile('test.dart', '''
+import 'package:meta/meta.dart';
+@alwaysThrows toss() { throw 'Thrown'; }
+''');
+      final expectedOutput = '''
+import 'package:meta/meta.dart';
+Never toss() { throw 'Thrown'; }
+''';
+      expectSuggestorGeneratesPatches(
+          AlwaysThrowsFixer(), context, expectedOutput);
+    });
+  });
+}
+```
+
 ## References
 
 - [over_react_codemod][over_react_codemod]: codemods for the `over_react` UI

--- a/dart_dependency_validator.yaml
+++ b/dart_dependency_validator.yaml
@@ -1,0 +1,3 @@
+ignore:
+  # Flagged as a false positive due to one of the unit test files
+  - meta

--- a/lib/test.dart
+++ b/lib/test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:analyzer/dart/analysis/analysis_context_collection.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
@@ -8,35 +10,6 @@ import 'src/suggestor.dart';
 import 'src/util.dart';
 
 export 'src/util.dart' show applyPatches;
-
-/// Creates a file with the given [name] and [sourceText] using the
-/// `test_descriptor` package, sets up analysis for that file, and returns a
-/// [FileContext] wrapper around it.
-///
-/// Use this to setup tests for [Suggestor]s:
-///     test('My suggestor', () async {
-///       var context = await fileContextForTest('foo.dart', 'library foo; // etc');
-///       var patches = MySuggestor().generatePatches(context);
-///       expect(patches, ...);
-///     });
-Future<FileContext> fileContextForTest(String name, String sourceText) async {
-  // Use test_descriptor to create the file in a temporary directory
-  d.Descriptor descriptor;
-  final segments = p.split(name);
-  // Last segment should be the file
-  descriptor = d.file(segments.last, sourceText);
-  // Any preceding segments (if any) are directories
-  for (final dir in segments.reversed.skip(1)) {
-    descriptor = d.dir(dir, [descriptor]);
-  }
-  await descriptor.create();
-
-  // Setup analysis for this file
-  final path = p.canonicalize(p.join(d.sandbox, name));
-  final collection = AnalysisContextCollection(includedPaths: [path]);
-
-  return FileContext(path, collection, root: d.sandbox);
-}
 
 /// Uses [suggestor] to generate a stream of patches for [context] and returns
 /// what the resulting file contents would be after applying all of them.
@@ -55,4 +28,131 @@ void expectSuggestorGeneratesPatches(
           .toList()
           .then((patches) => applyPatches(context.sourceFile, patches)),
       completion(resultMatcher));
+}
+
+/// Creates a temporary file with the given [name] and [sourceText] using the
+/// `test_descriptor` package, sets up analysis for that file, and returns a
+/// [FileContext] wrapper around it.
+///
+/// Use this to setup tests for [Suggestor]s:
+///     test('My suggestor', () async {
+///       var context = await fileContextForTest('foo.dart', 'library foo; // etc');
+///       var patches = MySuggestor().generatePatches(context);
+///       expect(patches, ...);
+///     });
+///
+/// See also: [PackageContextForTest] if testing [Suggestor]s that need a fully
+/// resolved AST from the analyzer.
+Future<FileContext> fileContextForTest(String name, String sourceText) async {
+  // Use test_descriptor to create the file in a temporary directory
+  d.Descriptor descriptor;
+  final segments = p.split(name);
+  // Last segment should be the file
+  descriptor = d.file(segments.last, sourceText);
+  // Any preceding segments (if any) are directories
+  for (final dir in segments.reversed.skip(1)) {
+    descriptor = d.dir(dir, [descriptor]);
+  }
+  await descriptor.create();
+
+  // Setup analysis for this file
+  final path = p.canonicalize(d.path(name));
+  final collection = AnalysisContextCollection(includedPaths: [path]);
+
+  return FileContext(path, collection, root: d.sandbox);
+}
+
+/// Creates a temporary directory with a pubspec using the `test_descriptor`
+/// package, installs dependencies with `dart pub get`, and sets up an analysis
+/// context for the package.
+///
+/// Source files can then be added to the package with [addFile], which will
+/// return a [FileContext] wrapper for use in tests.
+///
+/// Use this to setup tests for [Suggestor]s that require the resolved AST, like
+/// the [AstVisitingSuggestor] when `shouldResolveAst()` returns true. Doing so
+/// will enable the analyzer to resolve imports and symbols from other source
+/// files and dependencies.
+///     test('MySuggestor', () async {
+///       var pkg = await PackageContextForTest.fromPubspec('pkg', '''
+///     name: pkg
+///     version: 0.0.0
+///     environment:
+///       sdk: '>=3.0.0 <4.0.0'
+///     dependencies:
+///       meta: ^1.0.0
+///     ''');
+///       var context = await pkg.addFile('foo.dart', '''
+///     import 'package:meta/meta.dart';
+///     @visibleForTesting var foo = true;
+///     ''');
+///       var suggestor = MySuggestor();
+///       var expectedOutput = '...';
+///       expectSuggestorGeneratesPatches(suggestor, context, expectedOutput);
+///     });
+class PackageContextForTest {
+  final AnalysisContextCollection _collection;
+  final String _name;
+  final String _root;
+
+  /// Creates a temporary directory named [dirName] using the `test_descriptor`
+  /// package, installs dependencies with `dart pub get`, sets up an analysis
+  /// context for the package, and returns a [PackageContextForTest] wrapper
+  /// that allows you to add source files to the package and use them in tests.
+  ///
+  /// Throws an [ArgumentError] if it fails to install dependencies.
+  static Future<PackageContextForTest> fromPubspec(
+    String dirName,
+    String pubspecContents,
+  ) async {
+    await d.dir(dirName, [
+      d.file('pubspec.yaml', pubspecContents),
+    ]).create();
+
+    final root = p.canonicalize(d.path(dirName));
+    final pubGet =
+        Process.runSync('dart', ['pub', 'get'], workingDirectory: root);
+    if (pubGet.exitCode != 0) {
+      printOnFailure('''
+PROCESS: dart pub get
+WORKING DIR: $root
+STDOUT:
+${pubGet.stdout}
+STDERR:
+${pubGet.stderr}
+''');
+      throw ArgumentError('Failed to install dependencies from given pubspec');
+    }
+    final collection = AnalysisContextCollection(includedPaths: [root]);
+    return PackageContextForTest._(dirName, root, collection);
+  }
+
+  PackageContextForTest._(this._name, this._root, this._collection);
+
+  /// Creates a temporary file at the given [path] (relative to the root of this
+  /// package) with the given [sourceText] using the `test_descriptor` package
+  /// and returns a [FileContext] wrapper around it.
+  ///
+  /// The returned [FileContext] will use the analysis context for this whole
+  /// package rather than just this file, which enables testing of [Suggestor]s
+  /// that require the resolved AST.
+  ///
+  /// See [PackageContextForTest] for an example.
+  Future<FileContext> addFile(String path, String sourceText) async {
+    // Use test_descriptor to create the file in a temporary directory
+    d.Descriptor descriptor;
+    final segments = p.split(path);
+    // Last segment should be the file
+    descriptor = d.file(segments.last, sourceText);
+    // Any preceding segments (if any) are directories
+    for (final dir in segments.reversed.skip(1)) {
+      descriptor = d.dir(dir, [descriptor]);
+    }
+    // Add the root directory.
+    descriptor = d.dir(_name, [descriptor]);
+    await descriptor.create();
+
+    final canonicalizedPath = p.canonicalize(p.join(d.sandbox, _name, path));
+    return FileContext(canonicalizedPath, _collection, root: _root);
+  }
 }

--- a/test/ast_visiting_suggestor_test.dart
+++ b/test/ast_visiting_suggestor_test.dart
@@ -119,7 +119,7 @@ void main() {
     });
 
     test('should resolve AST and work with imports', () async {
-      final pkg = await PackageContextForTest.fromPubspec('pkg', '''
+      final pkg = await PackageContextForTest.fromPubspec('''
 name: pkg
 publish_to: none
 environment:
@@ -127,7 +127,7 @@ environment:
 dependencies:
   meta: ^1.0.0
 ''');
-      final context = await pkg.addFile('test.dart', '''
+      final context = await pkg.addFile('''
 import 'package:meta/meta.dart';
 @alwaysThrows toss() { throw 'Thrown'; }
 ''');

--- a/test/ast_visiting_suggestor_test.dart
+++ b/test/ast_visiting_suggestor_test.dart
@@ -46,6 +46,24 @@ class LibNameDoubler extends RecursiveAstVisitor<void>
   }
 }
 
+class AlwaysThrowsFixer extends GeneralizingAstVisitor<void>
+    with AstVisitingSuggestor {
+  @override
+  bool shouldResolveAst(_) => true;
+
+  @override
+  void visitFunctionDeclaration(FunctionDeclaration node) {
+    for (final annotation in node.metadata) {
+      final isAlwaysThrows = annotation.name.name == 'alwaysThrows';
+      final annotationPackage = annotation.element?.library?.identifier ?? '';
+      final isFromPackageMeta = annotationPackage.startsWith('package:meta/');
+      if (isAlwaysThrows && isFromPackageMeta) {
+        yieldPatch('Never', annotation.offset, annotation.end);
+      }
+    }
+  }
+}
+
 void main() {
   group('AstVisitingSuggestor', () {
     test('should get compilation unit, visit it, and yield patches', () async {
@@ -98,6 +116,27 @@ void main() {
       expect(await patchesB.toList(), [Patch('bb', 8, 9)]);
       expect(await patchesA.toList(), [Patch('aa', 8, 9)]);
       expect(await patchesC.toList(), [Patch('cc', 8, 9)]);
+    });
+
+    test('should resolve AST and work with imports', () async {
+      final pkg = await PackageContextForTest.fromPubspec('pkg', '''
+name: pkg
+publish_to: none
+environment:
+  sdk: '>=2.19.0 <4.0.0'
+dependencies:
+  meta: ^1.0.0
+''');
+      final context = await pkg.addFile('test.dart', '''
+import 'package:meta/meta.dart';
+@alwaysThrows toss() { throw 'Thrown'; }
+''');
+      final expectedOutput = '''
+import 'package:meta/meta.dart';
+Never toss() { throw 'Thrown'; }
+''';
+      expectSuggestorGeneratesPatches(
+          AlwaysThrowsFixer(), context, expectedOutput);
     });
   });
 }


### PR DESCRIPTION
## Motivation
`AstVisitingSuggestor` makes it easy to write suggestors that resolve the AST by overriding `shouldResolveAst()`, but we don't make it very easy to test those suggestors, especially on files that have imports.

## Changes
Add `PackageContextForTest` to help with this use case. See readme for details.