### PR TITLE
Raise the meta dependency min to v1.16.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,6 +26,6 @@ dev_dependencies:
   build_runner: ^2.0.1
   dart_style: ^2.0.0
   dependency_validator: ^3.0.0
-  meta: ^1.6.0
+  meta: ^1.16.0
   mocktail: ^1.0.1
   pedantic: ^1.11.0


### PR DESCRIPTION
This PR raises the min version of meta to 1.16.0. Passing CI
should be sufficient for QA, so feel free to review and merge this once CI completes.

For more info, reach out to `#support-frontend-dx` on Slack.

[_Created by Sourcegraph batch change `Workiva/meta_raise_min_v1_16_0_really`._](https://workiva.sourcegraphcloud.com/organizations/Workiva/batch-changes/meta_raise_min_v1_16_0_really)